### PR TITLE
json-format logging handler added

### DIFF
--- a/salt/log/handlers/json_file.py
+++ b/salt/log/handlers/json_file.py
@@ -1,0 +1,84 @@
+# Import python libs
+from __future__ import absolute_import
+import json
+import logging
+import logging.handlers
+import datetime
+import threading
+
+# Import salt libs
+from salt.log.setup import LOG_LEVELS
+from salt.log.mixins import NewStyleClassMixIn
+import salt.utils.network
+
+
+log = logging.getLogger(__name__)
+
+# Define the module's virtual name
+__virtualname__ = 'json_file'
+
+
+def __virtual__():
+    if not 'json_file' in __opts__:
+        log.trace(
+            'No json_file_path is selected.'
+            'Not loading the json_file '
+            'logging handlers module.'
+        )
+        return False
+    return __virtualname__
+
+def setup_handlers():
+    if 'json_file' in __opts__:
+        root_dir = __opts__.get('root_dir', '')
+        if 'master' in __opts__:
+            default_path = '/var/log/salt/minion.json'
+        else:
+            default_path = '/var/log/salt/master.json'
+
+        path = root_dir + __opts__['json_file'].get('logfile_path', default_path)
+        json_formatter = JsonFormatter()
+        json_handler = logging.FileHandler(filename=path)
+        json_handler.setFormatter(json_formatter)
+        json_handler.setLevel(
+            LOG_LEVELS[
+                __opts__['json_file'].get(
+                    'log_level',
+                    # Not set? Get the main salt log_level setting on the
+                    # configuration file
+                    __opts__.get(
+                        'log_level',
+                        # Also not set?! Default to 'error'
+                        'error'
+                    )
+                )
+            ]
+        )
+        yield json_handler
+
+
+class JsonFormatter(logging.Formatter, NewStyleClassMixIn):
+    def __init__(self):
+        self.format = getattr(self, 'set_format')
+        super(JsonFormatter, self).__init__(fmt=None, datefmt=None)
+
+    def formatTime(self, record, datefmt=None):
+        return datetime.datetime.utcfromtimestamp(record.created).isoformat()[:-3] + 'Z'
+
+    def set_format(self, record):
+        message_dict = {
+            '@timestamp': self.formatTime(record),
+            'host': salt.utils.network.get_fqhostname(),
+            'levelname': record.levelname,
+            'logger': record.name,
+            'lineno': record.lineno,
+            'pathname': record.pathname,
+            'process': record.process,
+            'threadName': record.threadName,
+            'funcName': record.funcName,
+            'processName': record.processName,
+            'message': record.getMessage()
+        }
+        if hasattr(record,'jid') and record.jid != '':
+            message_dict['jid'] = record.jid
+        return json.dumps(message_dict)


### PR DESCRIPTION
To enable logging in JSON-format just add this params into master and minion config:
```
json_file:
  logfile_path: /var/log/salt/master.json
  log_level: info
```
default log_level: warning
default logfile_path: /var/log/salt/(master|minion).json